### PR TITLE
Make results and scratch directory creation faster

### DIFF
--- a/src/roles/experiment-job/tasks/main.yml
+++ b/src/roles/experiment-job/tasks/main.yml
@@ -80,29 +80,14 @@
     #  Prepare Experiment Environment (directories, files, ...)       #
     ###################################################################
 
-  - name: Create results directory
-    ansible.builtin.file:
-        path: "{{ job.exp_working_dir }}/results"
-        state: directory
-        mode: 0755
-        group: ubuntu
-        owner: ubuntu
-    delegate_to: "{{ job.host_info.public_dns_name }}"
-    loop: "{{ exp_jobs_to_enqueue }}"
+  - name: Create results and scratch directories (per-host)
+    ansible.builtin.shell: |
+      mkdir -m755 -p {{ '{' }}{{ jobs_grouped | last | map(attribute='exp_working_dir') | map('regex_replace', '^(.*)$', '\1/scratch') | join(',') }}{{ '}' }}
+      mkdir -m755 -p {{ '{' }}{{ jobs_grouped | last | map(attribute='exp_working_dir') | map('regex_replace', '^(.*)$', '\1/results') | join(',') }}{{ '}' }}
+    delegate_to: "{{ jobs_grouped | first }}" # first entry in group
+    loop: "{{ exp_jobs_to_enqueue | groupby('host_info.public_dns_name') }}"
     loop_control:
-        loop_var: job
-
-  - name: Create scratch directory
-    ansible.builtin.file:
-        path: "{{ job.exp_working_dir }}/scratch"
-        state: directory
-        mode: 0755
-        group: ubuntu
-        owner: ubuntu
-    delegate_to: "{{ job.host_info.public_dns_name }}"
-    loop: "{{ exp_jobs_to_enqueue }}"
-    loop_control:
-        loop_var: job
+        loop_var: jobs_grouped
 
   - name: Create run config file in working directory
     template:


### PR DESCRIPTION
When there are many (e.g., 100) jobs, the Doe suite would use an ansible loop over all jobs to create `results` and `scratch` directories, but this was quite slow, because any ansible command has a considerable setup overhead (even things like `file`). 

Instead of having to wait for the ansible loop, this optimization groups the jobs per host, and then invokes a manual `mkdir` with the correct permissions*, which is much faster!

* Permission 755, and as `owner` the ansible user, which is consistent with previous behavior