### PR TITLE
Extend ETL base

### DIFF
--- a/src/scripts/etl_base.py
+++ b/src/scripts/etl_base.py
@@ -159,8 +159,6 @@ class RepAggTransformer(Transformer):
 
         agg_functions = options.get("agg_functions", ['mean', 'min', 'max', 'std', 'count'])
 
-
-
         if not set(data_columns).issubset(df.columns.values):
             raise ValueError(f"RepAggTransformer: data_columns={data_columns} must be in df_columns={df.columns.values}")
 
@@ -188,6 +186,71 @@ class RepAggTransformer(Transformer):
         return df
 
 
+class FactorAggTransformer(Transformer):
+
+    """
+    Transformer to aggregate over specified factors of the same experiment run.
+
+    GroupBy `factor_columns` of df.
+    Afterward, apply specified aggregate functions `agg_functions` on the `data_columns`.
+    """
+
+    def transform(self, df: pd.DataFrame, options: Dict) -> pd.DataFrame:
+        # TODO [nku] test and remove
+        #return df
+        if df.empty:
+            return df
+
+        data_columns = options.get("data_columns")
+        factor_columns = options.get("factor_columns")
+
+        agg_functions = options.get("agg_functions", ['mean', 'min', 'max', 'std', 'count'])
+
+        # custom agg functions
+        custom_agg_methods_available = {
+            "custom_tail": self.custom_tail
+        }
+        for fun in agg_functions.copy():
+            for method, call in custom_agg_methods_available.items():
+                if fun == method:
+                    agg_functions.remove(fun) # is this allowed while in the loop?
+                    agg_functions.append(call)
+
+
+        if not set(data_columns).issubset(df.columns.values):
+            return df
+            # raise ValueError(f"RepAggTransformer: data_columns={data_columns} must be in df_columns={df.columns.values}")
+        if not set(factor_columns).issubset(df.columns.values):
+            raise ValueError(f"FactorAggTransformer: factor_columns={factor_columns} must be in df_columns={df.columns.values}")
+
+        # ensure that all data_columns are numbers
+        df[data_columns] = df[data_columns].apply(pd.to_numeric)
+
+        # we need to convert each column into a hashable type (list and dict are converted to string)
+        hashable_types={}
+        for col in df.columns:
+            dtype = df[col].dtype
+            if  dtype == "object":
+                hashable_types[col] = "str"
+            else:
+                hashable_types[col] = dtype
+        df = df.astype(hashable_types)
+
+        # group_by all except `rep` and `data_columns`
+        group_by_cols = factor_columns
+        agg_d = {data_col: agg_functions for data_col in data_columns}
+        df = df.groupby(group_by_cols).agg(agg_d).reset_index()
+
+        # flatten columns
+        df.columns = ["_".join(v) if v[1] else v[0] for v in df.columns.values]
+
+        return df
+
+    def custom_tail(self, data):
+        # print("data", data, data.tail(5).mean())
+        return data.tail(5).mean()
+
+
 
 ########################################################
 # Loaders                                              #
@@ -195,4 +258,18 @@ class RepAggTransformer(Transformer):
 
 class CsvSummaryLoader(Loader):
     def load(self, df: pd.DataFrame, options: Dict, etl_info: Dict) -> None:
+        if df.empty:
+            print("CsvSummaryLoader: DataFrame is empty so not creating an output file.")
         df.to_csv(os.path.join(etl_info["suite_dir"], f"{etl_info['pipeline']}.csv"))
+
+
+class LatexTableLoader(Loader):
+    """
+    Prints dataframe as LaTeX table
+    """
+    def load(self, df: pd.DataFrame, options: Dict, etl_info: Dict) -> None:
+        if df.empty:
+            print("LatexTableLoader: DataFrame is empty so not creating an output file.")
+
+        with open(os.path.join(etl_info["suite_dir"], f"{etl_info['pipeline']}.txt")) as file:
+            df.to_latex(buf=file)


### PR DESCRIPTION
This PR adds:
- `FactorAggTransformer` Aggregate data over experiment runs, based on `RepAggTransformer`. Aggregates `data_columns` over `factor_columns`
- `LatexTableLoader` Outputs DataFrame as Latex table using `df.to_latex`