### PR TITLE
Super ETL suite_id dict via cmd + run config for extractors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ ifdef pipelines
 	mypipelines=--pipelines $(pipelines)
 endif
 
+ifdef custom-suite-id # custom-suite-id="<suite>=<id> <suite>=<id>"
+	mycustomsuiteid=--suite_id $(custom-suite-id)
+endif
+
 # on `make` and `make help` list all targets with information
 help:
 	@echo 'Running Experiments'
@@ -175,7 +179,7 @@ etl-all: install
 # e.g., make etl-super config=demo_plots out=/home/kuenico/dev/doe-suite/tmp
 etl-super: install
 	@cd $(does_config_dir) && \
-	poetry run python $(PWD)/doespy/doespy/etl/super_etl.py --config $(config) --output_path $(out) $(mypipelines)
+	poetry run python $(PWD)/doespy/doespy/etl/super_etl.py --config $(config) --output_path $(out) $(mypipelines) $(mycustomsuiteid)
 
 # delete etl results for a specific `suite` and `id`  (can be regenerated with `make etl suite=<SUITE> id=<ID>`)
 etl-clean: install

--- a/doespy/doespy/etl/super_etl.py
+++ b/doespy/doespy/etl/super_etl.py
@@ -5,10 +5,6 @@ from doespy import util
 
 def main():
 
-    # TODO [nku] validate the super-etl design with pydantic?
-
-    # TODO [nku] allow for super-etl to be located in a different directory? -> specifically, the results of the super-etl should be in the same directory as the super-etl config
-
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("--config", type=str, required=True)
     parser.add_argument(
@@ -42,6 +38,25 @@ def main():
         help="ETL super pipelines to run. If not specified, all pipelines will be run.",
     )
 
+
+    class KeyValue(argparse.Action):
+
+        def __call__( self , parser, namespace,
+                    values, option_string = None):
+            setattr(namespace, self.dest, dict())
+
+            for value in values:
+                # split it into key and value
+                key, value = value.split('=')
+                # assign into dictionary
+                getattr(namespace, self.dest)[key] = value
+
+    parser.add_argument('--suite_id',
+                    nargs='*',
+                    action = KeyValue,
+                    required=False,
+                    help="Replace the $SUITE_ID$ configured in the super etl design, e.g., --suite_id <suite>=<suite_id> <suite>=<suite_id>",)
+
     args = parser.parse_args()
 
     etl_base.run_multi_suite(
@@ -51,6 +66,7 @@ def main():
         flag_output_dir_pipeline=not args.output_dir_pipeline,
         etl_from_design=args.load_from_design,
         pipeline_filter=args.pipelines,
+        overwrite_suite_id_map=args.suite_id,
         return_df=False,
     )
 


### PR DESCRIPTION
- Each super ETL configuration starts with a `$SUITE_ID$` dictionary, specifying the run ids for the results. With this update, we introduce support to replace this dictionary via the command line.

- Extractors now receive the run config as part of their options. This enhancement enables more intricate extractors to implement advanced functionalities, such as implementing filters during the extraction stage. As this does not change the Extractors' interface, we ensure backward compatibility.