### PR TITLE
Updates from Arc artifact eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ We use annotated git tags for each release commit:
 
 
 -->
+## [1.2.0] - 2024-08-09
+
+### Added
+
+- Add `DOES_RESULTS_DIR` environment variable to change the default results dir `<DOES_PROJECT_DIR>/doe-suite-results` (can be useful for artefact evaluation)
+
+### Changed
+
+- Extend `etl_debug.py` to include an option to specify `overwrite_suite_id_map` that will overwrite specific suite ids in a super_etl.
+  The `overwrite_suite_id_map` can now also be used to filter `pipeline.experiments` in super etl designs.
 
 ## [1.1.1] - 2024-05-30
 

--- a/Makefile
+++ b/Makefile
@@ -379,9 +379,3 @@ docs-build: install
 
 docs: docs-build
 	@open docs/build/html/index.html
-
-
-## Checks does_config_dir is set
-does_set:
-	@if [ ! -d "$(does_config_dir)" ]; then echo "DOES_PROJECT_DIR is not set, please set environment variables"; exit 1; fi
-

--- a/Makefile
+++ b/Makefile
@@ -385,4 +385,4 @@ jupyter: install cloud-check
 	@cd $(does_config_dir) && \
 	ANSIBLE_CONFIG=$(PWD)/ansible.cfg \
 	ANSIBLE_INVENTORY=$(ansible_inventory) \
-	poetry run jupyter lab --notebook-dir $(PWD)/../
+	poetry run jupyter lab --ip 0.0.0.0 --port 8888 --notebook-dir $(PWD)/../

--- a/Makefile
+++ b/Makefile
@@ -379,3 +379,10 @@ docs-build: install
 
 docs: docs-build
 	@open docs/build/html/index.html
+
+
+jupyter: install cloud-check
+	@cd $(does_config_dir) && \
+	ANSIBLE_CONFIG=$(PWD)/ansible.cfg \
+	ANSIBLE_INVENTORY=$(ansible_inventory) \
+	poetry run jupyter lab --notebook-dir $(PWD)/../

--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,8 @@ does_set:
 
 jupyter: does_set install cloud-check
 	@cd $(does_config_dir) && \
+	(cd ../MP-SPDZ && Scripts/setup-ssl.sh) && \
+    (cd ../MP-SPDZ && Scripts/setup-ssl.sh 10 Player-SSL-Data) && \
 	ANSIBLE_CONFIG=$(PWD)/ansible.cfg \
 	ANSIBLE_INVENTORY=$(ansible_inventory) \
 	poetry run jupyter lab --ip 0.0.0.0 --port 8888 --notebook-dir $(PWD)/../

--- a/Makefile
+++ b/Makefile
@@ -385,10 +385,3 @@ docs: docs-build
 does_set:
 	@if [ ! -d "$(does_config_dir)" ]; then echo "DOES_PROJECT_DIR is not set, please set environment variables"; exit 1; fi
 
-jupyter: does_set install cloud-check
-	@cd $(does_config_dir) && \
-	(cd ../MP-SPDZ && Scripts/setup-ssl.sh) && \
-    (cd ../MP-SPDZ && Scripts/setup-ssl.sh 10 Player-SSL-Data) && \
-	ANSIBLE_CONFIG=$(PWD)/ansible.cfg \
-	ANSIBLE_INVENTORY=$(ansible_inventory) \
-	poetry run jupyter lab --ip 0.0.0.0 --port 8888 --notebook-dir $(PWD)/../

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,11 @@ docs: docs-build
 	@open docs/build/html/index.html
 
 
-jupyter: install cloud-check
+## Checks does_config_dir is set
+does_set:
+	@if [ ! -d "$(does_config_dir)" ]; then echo "DOES_PROJECT_DIR is not set, please set environment variables"; exit 1; fi
+
+jupyter: does_set install cloud-check
 	@cd $(does_config_dir) && \
 	ANSIBLE_CONFIG=$(PWD)/ansible.cfg \
 	ANSIBLE_INVENTORY=$(ansible_inventory) \

--- a/docs/source/developer/etl.rst
+++ b/docs/source/developer/etl.rst
@@ -183,12 +183,13 @@ Full example
 
 .. code:: python
 
-   %env DOES_PROJECT_DIR= # place correct dir here
-   import sys
-   import os
-   sys.path.insert(0, os.path.abspath('doe-suite/src/scripts'))
-   import super_etl
+    %env DOES_PROJECT_DIR= # place correct dir here
+    import sys
+    import os
+    sys.path.insert(0, os.path.abspath('doe-suite/doespy'))
+    display(sys.path)
+    import doespy.etl.etl_base as etl_base
 
-   df = super_etl.run_multi_suite("pipeline.yml", return_df=True)
+   df = super_etl.run_multi_suite("pipeline.yml", "etl_output", return_df=True)
 
    # inspect df

--- a/doespy/doespy/etl/etl_base.py
+++ b/doespy/doespy/etl/etl_base.py
@@ -261,6 +261,16 @@ def _load_super_etl_design(name, overwrite_suite_id_map=None):
         # overwrite suite id map
         pipeline_design["$SUITE_ID$"] = overwrite_suite_id_map
 
+        for pipeline_name, pipeline in pipeline_design["$ETL$"].items():
+            if pipeline_name == "$SUITE_ID$":
+                continue
+
+            # delete experiments that are not in the overwrite_suite_id_map
+            for suite in list(pipeline["experiments"].keys()):
+                if suite not in overwrite_suite_id_map.keys():
+                    # print("Removing suite", suite, "from pipeline", pipeline_name)
+                    del pipeline["experiments"][suite]
+
     model = SuperETL(**pipeline_design)
 
     pipeline_design_str = model.json(by_alias=True, exclude_none=True)

--- a/doespy/doespy/etl/etl_debug.py
+++ b/doespy/doespy/etl/etl_debug.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import Type, Union, Optional, Dict
 from doespy import util
 import pandas as pd
 import ruamel.yaml
@@ -6,13 +6,19 @@ import os
 
 from doespy.etl.steps.transformers import Transformer
 from doespy.etl.steps.loaders import Loader
-from functools import lru_cache
+from functools import lru_cache, wraps
 
 from doespy.etl.etl_base import run_multi_suite
 from doespy.design import etl_design
 
+class HDict(dict):
+    """Allows us to pass a dictionary to this cached function"""
+    def __hash__(self):
+        return hash(frozenset(self.items()))
+
 @lru_cache(maxsize=1)
-def debug_compute_input_df(super_etl: str , pipeline: str, StepCls: Type[Union[Transformer, Loader]]):
+def debug_compute_input_df(super_etl: str , pipeline: str, StepCls: Type[Union[Transformer, Loader]],
+                           overwrite_suite_id_map: Optional[HDict[str, str]]=None):
     """
     Computes the input dataframe for a given step in the super_etl pipeline.
 
@@ -34,9 +40,12 @@ def debug_compute_input_df(super_etl: str , pipeline: str, StepCls: Type[Union[T
             pipeline_filter=[pipeline],
             return_df=True,
             return_df_until_transformer_step=return_df_until_transformer_step,
+            overwrite_suite_id_map=overwrite_suite_id_map
         )
-
-    return df_cached[pipeline]
+    if df_cached is not None:
+        return df_cached[pipeline]
+    else:
+        return pd.DataFrame()
 
 
 def debug_super_etl_step(super_etl: str, pipeline: str, StepCls, df: pd.DataFrame):
@@ -73,7 +82,7 @@ def debug_super_etl_step(super_etl: str, pipeline: str, StepCls, df: pd.DataFram
 
         cfg = cfg["loaders"][StepCls.__name__]
 
-        print(f"Config={cfg=}")
+        # print(f"Config={cfg=}")
         step = StepCls(**cfg)
 
         etl_info = {

--- a/doespy/doespy/etl/etl_debug.py
+++ b/doespy/doespy/etl/etl_debug.py
@@ -82,7 +82,7 @@ def debug_super_etl_step(super_etl: str, pipeline: str, StepCls, df: pd.DataFram
 
         cfg = cfg["loaders"][StepCls.__name__]
 
-        # print(f"Config={cfg=}")
+        print(f"Config={cfg=}")
         step = StepCls(**cfg)
 
         etl_info = {

--- a/doespy/doespy/util.py
+++ b/doespy/doespy/util.py
@@ -94,8 +94,8 @@ def get_suite_roles_dir():
 
 def get_results_dir():
     prj_dir = get_project_dir()
-    results_dir_name = os.environ.get("DOES_RESULTS_DIR", "doe-suite-results")
-    results_dir = os.path.join(prj_dir, results_dir_name)
+    results_dir_name = "doe-suite-results"
+    results_dir = os.environ.get("DOES_RESULTS_DIR", os.path.join(prj_dir, results_dir_name))
     return results_dir
 
 

--- a/doespy/doespy/util.py
+++ b/doespy/doespy/util.py
@@ -94,7 +94,8 @@ def get_suite_roles_dir():
 
 def get_results_dir():
     prj_dir = get_project_dir()
-    results_dir = os.path.join(prj_dir, "doe-suite-results")
+    results_dir_name = os.environ.get("DOES_RESULTS_DIR", "doe-suite-results")
+    results_dir = os.path.join(prj_dir, results_dir_name)
     return results_dir
 
 


### PR DESCRIPTION
- Extends `etl_debug.py` to include an option to specify `overwrite_suite_id_map` that will overwrite specific suite ids in a super_etl to override pipeline configurations from a Jupyter notebook (to run the the pipeline for the latest suite id for instance)
- Extends ETL to read a custom results directory from the `DOES_RESULTS_DIR` environment variable (to allow easy plotting of different sets of results, e.g., to plot results from the paper and newly obtained results side-by-side).