### PR TITLE
ETL Improvements

### DIFF
--- a/doespy/doespy/etl/steps/colcross/base.py
+++ b/doespy/doespy/etl/steps/colcross/base.py
@@ -2,6 +2,8 @@
 import abc
 import jmespath
 from typing import Dict, List
+
+import numpy
 from doespy.design.etl_design import MyETLBaseModel
 
 
@@ -17,6 +19,14 @@ def is_match(jp_query, data_id, info) -> bool:
 
     # print(f"    -> is match: {result}")
     # print(f"JmesPathFilter: {info}: query is {result}    {jp_query=}")
+    if isinstance(result, numpy.bool_): # For some queries the result is a numpy.bool_ type
+        result = bool(result)
+    if isinstance(result, str):
+        if result.lower() == "true":
+            result = True
+        elif result.lower() == "false":
+            result = False
+
     assert isinstance(
         result, bool
     ), f"JmesPathFilter: {info}: query={jp_query} returned non-boolean result: {result}"

--- a/doespy/doespy/etl/steps/colcross/colcross.py
+++ b/doespy/doespy/etl/steps/colcross/colcross.py
@@ -136,13 +136,13 @@ class SubplotConfig(BaseSubplotConfig):
 
         # inherit label info from legend_ax or legend_fig
         if plot_config is not None and plot_config.legend_fig is not None and plot_config.legend_fig.label is not None:
-                base_label = plot_config.legend_fig.get_label(data_id=artist_id, subplot_config=self)
-                configs.append(ArtistConfig(jp_query=None, label=base_label))
+            base_label = plot_config.legend_fig.get_label(data_id=artist_id, subplot_config=self)
+            configs.append(ArtistConfig(jp_query=None, label=base_label))
         elif self.legend_ax is not None and self.legend_ax.label is not None:
-                base_label = self.legend_ax.get_label(
-                    data_id=artist_id, subplot_config=self
-                )
-                configs.append(ArtistConfig(jp_query=None, label=base_label))
+            base_label = self.legend_ax.get_label(
+                data_id=artist_id, subplot_config=self
+            )
+            configs.append(ArtistConfig(jp_query=None, label=base_label))
 
         return ArtistConfig.merge_cumulative(
             configs=configs, data_id=artist_id, subplot_config=self

--- a/doespy/doespy/etl/steps/colcross/colcross.py
+++ b/doespy/doespy/etl/steps/colcross/colcross.py
@@ -136,13 +136,13 @@ class SubplotConfig(BaseSubplotConfig):
 
         # inherit label info from legend_ax or legend_fig
         if plot_config is not None and plot_config.legend_fig is not None and plot_config.legend_fig.label is not None:
-            base_label = plot_config.legend_fig.get_label(data_id=artist_id, subplot_config=self)
-            configs.append(ArtistConfig(jp_query=None, label=base_label))
+                base_label = plot_config.legend_fig.get_label(data_id=artist_id, subplot_config=self)
+                configs.append(ArtistConfig(jp_query=None, label=base_label))
         elif self.legend_ax is not None and self.legend_ax.label is not None:
-            base_label = self.legend_ax.get_label(
-                data_id=artist_id, subplot_config=self
-            )
-            configs.append(ArtistConfig(jp_query=None, label=base_label))
+                base_label = self.legend_ax.get_label(
+                    data_id=artist_id, subplot_config=self
+                )
+                configs.append(ArtistConfig(jp_query=None, label=base_label))
 
         return ArtistConfig.merge_cumulative(
             configs=configs, data_id=artist_id, subplot_config=self

--- a/doespy/doespy/etl/steps/colcross/hooks.py
+++ b/doespy/doespy/etl/steps/colcross/hooks.py
@@ -150,6 +150,8 @@ def ax_legend(ax, df_subplot, subplot_id, plot_config, subplot_config, loader):
             for i, (h, l) in enumerate(zip(handles, labels))
             if l not in labels[:i]
         ]
+        # invert order
+        unique = unique[::-1]
 
         ax.legend(*zip(*unique), **subplot_config.legend_ax.kwargs)
 

--- a/doespy/doespy/etl/steps/colcross/hooks.py
+++ b/doespy/doespy/etl/steps/colcross/hooks.py
@@ -187,7 +187,7 @@ def axis(ax, df_subplot, subplot_id, plot_config, subplot_config, loader):
 
     if ycfg.lim is not None:
         ymin, ymax = ycfg.lim.limits(ax.yaxis.get_data_interval())
-        ax.set_xlim(ymin, ymax)
+        ax.set_ylim(ymin, ymax)
 
     # ticks
     if xcfg.ticks is not None:

--- a/doespy/doespy/etl/steps/colcross/subplots/bar.py
+++ b/doespy/doespy/etl/steps/colcross/subplots/bar.py
@@ -269,6 +269,9 @@ class GroupedStackedBarChart(MyETLBaseModel):
                         }
 
                         part_value = df_bar_part[value_col].iloc[0]
+                        if pd.isna(part_value):
+                            # print(f"Skipping part_value because it is None")
+                            continue
                         part_error = (
                             df_bar_part[error_col].iloc[0]
                             if error_col is not None


### PR DESCRIPTION
- Extends supports for more JMESPath queries (with numpy._bool and string return types)
- Fix bug in yaxis limit setting
- Invert legend label order by default to match bar_part order
- skip bar part drawing of nan values